### PR TITLE
Avoid loading when selinux is not present

### DIFF
--- a/selinux/__init__.py
+++ b/selinux/__init__.py
@@ -35,47 +35,47 @@ class add_path(object):
             pass
 
 
-def add_location(location):
-    """Try to add a possble location for the selinux module"""
-    if os.path.isdir(os.path.join(location, 'selinux')):
-        with add_path(location):
-            # And now we replace outselves with the original selinux module
-            reload(sys.modules['selinux'])
-            # Validate that we can perform libselinux calls
-            if sys.modules['selinux'].is_selinux_enabled() not in [0, 1]:
-                raise RuntimeError("is_selinux_enabled returned error.")
-            return True
-    return False
+# selinux python library should be loaded only on selinux systems
+if platform.system() == 'Linux' and os.path.isfile('/etc/selinux/config'):
 
+    def add_location(location):
+        """Try to add a possble location for the selinux module"""
+        if os.path.isdir(os.path.join(location, 'selinux')):
+            with add_path(location):
+                # And now we replace outselves with the original selinux module
+                reload(sys.modules['selinux'])
+                # Validate that we can perform libselinux calls
+                if sys.modules['selinux'].is_selinux_enabled() not in [0, 1]:
+                    raise RuntimeError("is_selinux_enabled returned error.")
+                return True
+        return False
 
-def get_system_sitepackages():
-    """Get sitepackage locations from sytem python"""
-    system_python = "/usr/bin/python%s" % platform.python_version_tuple()[0]
+    def get_system_sitepackages():
+        """Get sitepackage locations from sytem python"""
+        system_python = "/usr/bin/python%s" % \
+            platform.python_version_tuple()[0]
 
-    system_sitepackages = json.loads(
-        subprocess.check_output(
-            [system_python, "-c",
-             "import json, site; print(json.dumps(site.getsitepackages()))"
-             ]
-        ).decode("utf-8")
-    )
-    return system_sitepackages
+        system_sitepackages = json.loads(
+            subprocess.check_output([
+                system_python, "-c",
+                "import json, site; print(json.dumps(site.getsitepackages()))"
+                ]
+            ).decode("utf-8")
+        )
+        return system_sitepackages
 
+    def check_system_sitepackages():
+        """Try add selinux module from any of the python site-packages"""
 
-def check_system_sitepackages():
-    """Try add selinux module from any of the python site-packages"""
+        success = False
+        system_sitepackages = get_system_sitepackages()
+        for candidate in system_sitepackages:
+            success = add_location(candidate)
+            if success:
+                break
 
-    success = False
-    system_sitepackages = get_system_sitepackages()
-    for candidate in system_sitepackages:
-        success = add_location(candidate)
-        if success:
-            break
+        if not success:
+            raise Exception("Failed to detect selinux python bindings at %s" %
+                            system_sitepackages)
 
-    if not success:
-        raise Exception("Failed to detect selinux python bindings at %s" %
-                        system_sitepackages)
-
-
-if platform.system() == 'Linux':
     check_system_sitepackages()


### PR DESCRIPTION
Some Linux systems do not have selinux available or installed, so
we assure that we do not do anything if selinux is not detected on the
system. This is important in orderto allow people to add selinux
library as a dependency without very complex conditions.