### PR TITLE
Use pep517.build for packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ before_install:
 jobs:
   include:
     - script:
-        # package building added here purely to fail-fast if is broken
-        - python setup.py sdist bdist_wheel
         - travis_wait python -m tox
       env: TOXENV=lint,py27,molecule
       python: "2.7"

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,7 @@ commands =
 [testenv:dist]
 deps =
     collective.checkdocs>=0.2
+    pep517 >= 0.5.0
     pip>=19.1.1
     setuptools>=39.0
     twine>=1.13.0
@@ -75,7 +76,13 @@ deps =
 commands =
     rm -rf {toxinidir}/dist
     python setup.py check -m -s
-    python setup.py sdist bdist_wheel
+    # disabled due to errors with older setuptools:
+    # python setup.py sdist bdist_wheel
+    python -m pep517.build \
+      --source \
+      --binary \
+      --out-dir {toxinidir}/dist/ \
+      {toxinidir}
     python -m twine check {toxinidir}/dist/*
 
 [testenv:upload]


### PR DESCRIPTION
Avoids package building errors with older version of setuptools.