### PR TITLE
Add testing support for python3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ jobs:
     - name: py36
       python: "3.6"
       env: TOXENV=py36
+    - name: py38
+      python: "3.8-dev"
+      env: TOXENV=py38
     - name: py27
       python: "2.7"
       env: TOXENV=py27

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,dist,py27,py35,py36,py37,distros
+envlist = lint,dist,py27,py35,py36,py37,py38,distros
 minversion = 3.4.0
 ignore_basepython_conflict = True
 skip_missing_interpreters = True


### PR DESCRIPTION
Fedora-30 ships with python3.8 (beta), lets start testing with it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>