### PR TITLE
Reorder imp and importlib imports

### DIFF
--- a/selinux/__init__.py
+++ b/selinux/__init__.py
@@ -16,9 +16,9 @@ import subprocess
 import sys
 
 try:
-    from imp import reload  # type: ignore  # noqa
-except ImportError:  # py34+
     from importlib import reload  # type: ignore  # noqa
+except ImportError:  # py < 34
+    from imp import reload  # type: ignore  # noqa
 
 
 class add_path(object):


### PR DESCRIPTION
Python 3.4 deprecated the imp module in favor of importlib. Because we use imp module by default, using SELinux package with Python 3.4+ emits a deprecation warning:

> DeprecationWarning: the imp module is deprecated in favor of importlib; see the module's documentation for alternative uses

This commit makes the importlib default module and imp a fallback one.