### PR TITLE
Replace deprecated linux_distribution() method

### DIFF
--- a/selinux/__init__.py
+++ b/selinux/__init__.py
@@ -20,6 +20,8 @@ try:
 except ImportError:  # py34+
     from importlib import reload  # type: ignore  # noqa
 
+import distro
+
 
 class add_path(object):
     """Context manager for adding path to sys.path"""
@@ -45,18 +47,9 @@ def is_selinux_mls_enabled():
     return 0
 
 
-def linux_distribution():
-    # see https://github.com/easybuilders/easybuild/wiki/OS_flavor_name_version
-    try:
-        return platform.linux_distribution()[0].lower()
-    except Exception:
-        return "N/A"
-
-
 def should_have_selinux():
-    distro = linux_distribution()
     if platform.system() == "Linux" and os.path.isfile("/etc/selinux/config"):
-        if distro not in ["ubuntu", "debian"]:
+        if distro.id() not in ["ubuntu", "debian"]:
             return True
     return False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,9 @@ python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
 packages = find:
 include_package_data = True
 zip_safe = True
+install_requires =
+    distro>=1.3.0
+    setuptools>=39.0
 
 # These are required during `setup.py` run:
 setup_requires =
@@ -65,7 +68,6 @@ setup_requires =
     setuptools_scm_git_archive >= 1.0
 [options.packages.find]
 where = .
-install_requires = setuptools>=39.0
 
 [flake8]
 exclude = build .tox


### PR DESCRIPTION
As noted in the official documentation [1], linux_distribution method is deprecated and will be removed from Python 3.8.

In order to keep the existing functionality, we introduced distro package dependency that is linked from the official documentation.

[1] https://docs.python.org/3.7/library/platform.html