### PR TITLE
Consolidate dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,6 @@
 [build-system]
 requires = [
-  "pip>=19.1.1",
-  "setuptools >= 41.0.0",
-  "setuptools_scm >= 1.15.0",
-  "setuptools_scm_git_archive >= 1.0",
-  "wheel",
+  "setuptools >= 45.0.0",
+  "setuptools_scm[toml] >= 7.0.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,6 @@ install_requires =
 
 # These are required during `setup.py` run:
 setup_requires =
-    setuptools_scm >= 1.15.0
-    setuptools_scm_git_archive >= 1.0
+    setuptools_scm >= 7.0.0
 [options.packages.find]
 where = .

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,6 @@ include_package_data = True
 zip_safe = True
 install_requires =
     distro>=1.3.0
-    setuptools>=39.0
 
 # These are required during `setup.py` run:
 setup_requires =


### PR DESCRIPTION
Update build-system requirements by removing unneded tooling (pip, setuptools-scm-git-archive, wheel).
Remove setuptools from runtime requirements as it is not needed.

Closes #50 