### PR TITLE
Changed system_python = sys.executable

### DIFF
--- a/selinux/__init__.py
+++ b/selinux/__init__.py
@@ -71,9 +71,7 @@ if should_have_selinux():
 
     def get_system_sitepackages():
         """Get sitepackage locations from system python"""
-        # Do not ever use sys.executable here
-        # See https://github.com/pycontribs/selinux/issues/17 for details
-        system_python = "/usr/bin/python%s" % platform.python_version_tuple()[0]
+        system_python = sys.executable
 
         system_sitepackages = json.loads(
             subprocess.check_output(


### PR DESCRIPTION
```
13:35:52  Traceback (most recent call last):
13:35:52    File "/var/lib/jenkins/workspace/ocp-post-deployment-config/ocp-edge-qe-venv/bin/ansible-playbook", line 5, in <module>
13:35:52      from ansible.cli.playbook import main
13:35:52    File "/var/lib/jenkins/workspace/ocp-post-deployment-config/ocp-edge-qe-venv/lib/python3.8/site-packages/ansible/cli/__init__.py", line 55, in <module>
13:35:52      from ansible.module_utils.common.file import is_executable
13:35:52    File "/var/lib/jenkins/workspace/ocp-post-deployment-config/ocp-edge-qe-venv/lib/python3.8/site-packages/ansible/module_utils/common/file.py", line 25, in <module>
13:35:52      import selinux
13:35:52    File "/var/lib/jenkins/workspace/ocp-post-deployment-config/ocp-edge-qe-venv/lib/python3.8/site-packages/selinux/__init__.py", line 104, in <module>
13:35:52      check_system_sitepackages()
13:35:52    File "/var/lib/jenkins/workspace/ocp-post-deployment-config/ocp-edge-qe-venv/lib/python3.8/site-packages/selinux/__init__.py", line 100, in check_system_sitepackages
13:35:52      raise Exception(
13:35:52  Exception: Failed to detect selinux python bindings at ['/usr/local/lib64/python3.8/site-packages', '/usr/local/lib/python3.8/site-packages', '/usr/lib64/python3.8/site-packages', '/usr/lib/python3.8/site-packages']
```
We failed on hardcoded system_python. I switch it back to dynamic