### PR TITLE
Use major version if python installed in custom path

### DIFF
--- a/selinux/__init__.py
+++ b/selinux/__init__.py
@@ -77,6 +77,9 @@ if should_have_selinux():
             [str(item) for item in platform.python_version_tuple()[0:2]]
         )
 
+        if not os.path.isfile(system_python):
+            system_python = "/usr/bin/python%s" % platform.python_version_tuple()[0]
+
         system_sitepackages = json.loads(
             subprocess.check_output(
                 [


### PR DESCRIPTION
Switch to using python major version if python is installed on a custom path. Fix recent issues that seem to have risen due to #56 for @sophos-rickc and @sophos-daniels. 