### PR TITLE
Reinstate support for Python 3.7 and 3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,8 @@ classifiers =
 
     Operating System :: OS Independent
 
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -50,7 +52,7 @@ keywords =
 
 [options]
 use_scm_version = True
-python_requires = >=3.9
+python_requires = >=3.7
 packages = find:
 include_package_data = True
 zip_safe = True


### PR DESCRIPTION
Python 3.7 and 3.8 are still supported versions; they were inadvertently dropped along with end-of-life versions on #61

Fixes #63